### PR TITLE
✨  Domain `Workflow` and `Worker` bootstrap

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,29 @@
+name: ci
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    if: "!contains(github.event.head_commit.message, '[skip ci]')"
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run lint
+        run: npm run lint
+
+      - name: Run Tests
+        run: npm run test

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "name": "temporalight",
   "scripts": {
     "start:dev": "npm run ts",
+    "test": "npm run ts -- --test test/**/*.test.ts",
     "ts": "node --require esbuild-register",
     "type-check": "tsc --project tsconfig.json --noEmit",
     "lint": "yarn type-check && eslint ./src",

--- a/src/domain/worker.ts
+++ b/src/domain/worker.ts
@@ -1,0 +1,69 @@
+import { Workflow } from './workflow'
+
+export type Listener = (arg: any) => any
+
+export type EventBus = {
+  on: (eventName: string, listener: Listener) => void
+  off: (eventName: string) => void
+  send: <Event = unknown>(eventName: string, event: Event) => Promise<boolean>
+  close: () => Promise<void>
+}
+
+export type WorkerPayload<Payload = unknown> = {
+  workflowName: string
+  workflowId: string
+  payload: Payload
+}
+
+export type WorkerProxy = {
+  start: (workerPayload: WorkerPayload) => Promise<unknown>
+  run: (workerPayload: WorkerPayload) => Promise<unknown>
+}
+
+const runtimeId = (worker: WorkerPayload): string => `${worker.workflowName}:${worker.workflowId}`
+
+const createWorker =
+  (eventBus: EventBus) =>
+  <Payload = unknown, Response = unknown>(workflow: Workflow<Payload, Response>): void => {
+    eventBus.on(workflow.name, async (worker: WorkerPayload<Payload>) => {
+      const workflowId = runtimeId(worker)
+      await eventBus.send(workflowId, { status: 'START' })
+      try {
+        const result = await workflow.run(worker.payload)
+        await eventBus.send(workflowId, { status: 'SUCCEED', result })
+      } catch (error) {
+        await eventBus.send(workflowId, { status: 'FAIL', error })
+      }
+    })
+  }
+
+const createWorkerProxy = (eventBus: EventBus): WorkerProxy => {
+  return {
+    start: executeWorkflow(eventBus, false),
+    run: executeWorkflow(eventBus, true),
+  }
+}
+
+const executeWorkflow =
+  (eventBus: EventBus, waitForResult: boolean) => (workerPayload: WorkerPayload) =>
+    new Promise((resolve, reject) => {
+      const workflowId = runtimeId(workerPayload)
+      eventBus.on(workflowId, (runtime) => {
+        switch (runtime.status) {
+          case 'STARTED':
+            break
+          case 'SUCCEED':
+            eventBus.off(workflowId)
+            if (waitForResult) resolve(runtime.result)
+            break
+          case 'FAIL':
+            eventBus.off(workflowId)
+            if (waitForResult) reject(runtime.error)
+        }
+      })
+
+      const response = eventBus.send(workerPayload.workflowName, workerPayload)
+      if (!waitForResult) resolve(response)
+    })
+
+export { createWorker, runtimeId, createWorkerProxy }

--- a/src/domain/workflow.ts
+++ b/src/domain/workflow.ts
@@ -1,0 +1,14 @@
+export interface Workflow<Payload = unknown, Response = unknown> {
+  name: string
+  run: (args: Payload) => Promise<Response>
+}
+
+const workflow = <Payload = unknown, Response = unknown>(
+  workflowName: string,
+  func: (payload: Payload) => Promise<Response>,
+): Workflow<Payload, Response> => ({
+  name: workflowName,
+  run: func,
+})
+
+export { workflow }

--- a/src/infrastructure/bus/in-memory-event-bus.ts
+++ b/src/infrastructure/bus/in-memory-event-bus.ts
@@ -1,0 +1,29 @@
+import { EventEmitter } from 'events'
+
+import { EventBus, Listener } from '../../domain/worker'
+
+class InMemoryEventBus implements EventBus {
+  #eventEmitter: EventEmitter
+
+  constructor() {
+    this.#eventEmitter = new EventEmitter()
+  }
+
+  on(eventName: string, listener: Listener): void {
+    this.#eventEmitter.on(eventName, listener)
+  }
+
+  off(eventName: string): void {
+    this.#eventEmitter.removeAllListeners(eventName)
+  }
+
+  async send<Event>(eventName: string, event: Event): Promise<boolean> {
+    return this.#eventEmitter.emit(eventName, event)
+  }
+
+  async close(): Promise<void> {
+    // Nothing to do in this implementation
+  }
+}
+
+export { InMemoryEventBus }

--- a/test/domain/workflow.test.ts
+++ b/test/domain/workflow.test.ts
@@ -1,0 +1,63 @@
+import * as assert from 'assert'
+import { beforeEach, describe, it } from 'node:test'
+
+import {
+  createWorker,
+  createWorkerProxy,
+  EventBus,
+  WorkerProxy,
+} from '@workflow-runner/domain/worker'
+import { workflow } from '@workflow-runner/domain/workflow'
+import { InMemoryEventBus } from '@workflow-runner/infrastructure/bus/in-memory-event-bus'
+
+describe('Given a workflow nested in a worker', () => {
+  const greet = async (name: string): Promise<string> => {
+    console.log('Execute the greet workflow', name)
+    return `Hello, ${name}!`
+  }
+
+  let eventBus: EventBus
+
+  beforeEach(() => {
+    eventBus = new InMemoryEventBus()
+    createWorker(eventBus)(workflow('Greet', greet))
+  })
+
+  describe('the worker proxy runner', () => {
+    let workerProxy: WorkerProxy
+
+    beforeEach(() => {
+      workerProxy = createWorkerProxy(eventBus)
+    })
+
+    it('should return the workflow result when running', async () => {
+      const workflowResult = await workerProxy.run({
+        workflowName: 'Greet',
+        workflowId: '123',
+        payload: 'Jane Doe',
+      })
+
+      assert.strictEqual(workflowResult, 'Hello, Jane Doe!')
+    })
+
+    it('should return the workflow started status when starting', async () => {
+      const isWorkflowStarted = await workerProxy.start({
+        workflowName: 'Greet',
+        workflowId: '123',
+        payload: 'Jane Doe',
+      })
+
+      assert.strictEqual(isWorkflowStarted, true)
+    })
+
+    it('should return the workflow NOT started result when starting without workflow', async () => {
+      const isWorkflowStarted = await workerProxy.start({
+        workflowName: 'UnregisteredWorkflowName',
+        workflowId: '123',
+        payload: 'Jane Doe',
+      })
+
+      assert.strictEqual(isWorkflowStarted, false)
+    })
+  })
+})


### PR DESCRIPTION
A `Workflow` is, for now, a function that could be run through a remote trigger. It is defined by a `name` to be referenced.

A `Worker` allows running a `Workflow` on a specific environment.

 The trigger that starts the workflow and the Worker that executes the specified workflow could be one difference in processes. An `EventBus` is used to communicate between these 2 processes. In this first implementation, a simple in-memory event bus is implemented in order to test the flow.